### PR TITLE
Clean up CRA compilation warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5872,7 +5872,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5890,11 +5891,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5907,15 +5910,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6018,7 +6024,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6028,6 +6035,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6040,17 +6048,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6067,6 +6078,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6139,7 +6151,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6149,6 +6162,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6224,7 +6238,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6254,6 +6269,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6271,6 +6287,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6309,11 +6326,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/components/Navigation/Footer/Footer.js
+++ b/src/components/Navigation/Footer/Footer.js
@@ -18,7 +18,7 @@ const footer = (props) => {
                 </span>
             </div>
             <div>
-                <span>Questions or feedback? <a href="https://forms.gle/yq6vXYnaf3EbKKZS6" target="_blank">Contact Us</a></span>
+                <span>Questions or feedback? <a href="https://forms.gle/yq6vXYnaf3EbKKZS6" target="_blank" rel="noopener noreferrer">Contact Us</a></span>
             </div>
         </footer>
     );

--- a/src/containers/CallIn/CallIn.js
+++ b/src/containers/CallIn/CallIn.js
@@ -78,7 +78,7 @@ class CallIn extends Component {
         axios_api.get('districts').then((response)=>{
             const districts = response.data;
             const foundDistrict = districts.find((el)=>{
-                return (state.toLowerCase() == el.state.toLowerCase()) && (parseInt(number) == parseInt(el.number))
+                return (state.toLowerCase() === el.state.toLowerCase()) && (parseInt(number) === parseInt(el.number))
             })
             if(!foundDistrict){
                 throw Error(`No call-in details found for ${state}-${number}`)
@@ -95,7 +95,7 @@ class CallIn extends Component {
                     console.log(hydrated.script)
                     const talkingPoints = [...hydrated.script].map(el=>{
                         const theme = themes.find((el2)=>{return el2.themeId === el.themeId})
-                        el.theme = theme && theme.name || "Talking Point"
+                        el.theme = (theme && theme.name) || "Talking Point"
                         return el
                     })
                     this.setState({

--- a/src/containers/ScrollToTop/ScrollToTop.js
+++ b/src/containers/ScrollToTop/ScrollToTop.js
@@ -1,5 +1,5 @@
 import {withRouter} from 'react-router-dom';
-import React, {Component} from 'react';
+import {Component} from 'react';
 
 class ScrollToTop extends Component {
     componentDidUpdate(prevProps) {

--- a/src/util/district.js
+++ b/src/util/district.js
@@ -25,7 +25,7 @@ const comparator = (d1, d2) => {
         return 1;
     } else {
         if (dist1 < 0 && dist2 < 0) {
-            return (dist1 == -1) ? -1 : 1;
+            return (dist1 === -1) ? -1 : 1;
         }
         if (dist1 >= 0 && dist2 >= 0) {
             if (dist1 < dist2) {
@@ -40,7 +40,6 @@ const comparator = (d1, d2) => {
             return -1;
         }
     }
-    return 0;
 }
 
 const getAssociatedSenators = (district, districts) => {
@@ -48,13 +47,13 @@ const getAssociatedSenators = (district, districts) => {
         return []
     }
     return districts.filter(el => {
-        return isSenatorDistrict(el) && el.state == district.state && el.number != district.number;
+        return isSenatorDistrict(el) && el.state === district.state && el.number !== district.number;
     })
 }
 
 export {
-    isSenatorDistrict as isSenatorDistrict,
-    displayName as displayName,
-    comparator as comparator,
-    getAssociatedSenators as getAssociatedSenators,
+    isSenatorDistrict,
+    displayName,
+    comparator,
+    getAssociatedSenators,
 };


### PR DESCRIPTION
First pull request. Cleans up some minor warnings that hopefully should not affect any functionality.

This is useful if, e.g. in continuous integration pipelines you run `npm run build`, because CRA will fail the build if any warnings show up when `CI=true`.