### PR TITLE
Make api endpoint configurable via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
+# Project Grand Canyon - Public Site
+
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+
+## Developing with pgc-api
+
+To connect to a local instance of pgc-api, run `npm start` with the environment variable `REACT_APP_API_ENDPOINT=<url>`. By default, pgc-api listens on `http://localhost:8080/api`, so that would look like:
+
+`REACT_APP_API_ENDPOINT=http://localhost:8080//api/ npm start`
 
 ## Available Scripts
 

--- a/src/util/axios-api.js
+++ b/src/util/axios-api.js
@@ -1,8 +1,7 @@
 import axios from 'axios';
 
 const instance = axios.create({
-    baseURL: 'https://project-grand-canyon.appspot.com/api'
-    // baseURL: 'http://localhost:8080/api'
+    baseURL: process.env.REACT_APP_API_ENDPOINT || 'https://project-grand-canyon.appspot.com/api/'
 });
 
 export default instance;


### PR DESCRIPTION
This makes the documentation more clear for how to start the app with a local instance of the api server running. It's a bit more elegant than editing `src/util/axios-api.js`.

If you think this is a good approach, I'll submit the same PR to `pgc-admin`.