### PR TITLE
Hide `covid_paused` Follow-up Callers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1012,6 +1012,115 @@
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
+    "@emotion/cache": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "requires": {
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "@emotion/core": {
+      "version": "10.0.28",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.28.tgz",
+      "integrity": "sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "requires": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "requires": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "requires": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      }
+    },
+    "@emotion/sheet": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+    },
+    "@emotion/styled": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.27.tgz",
+      "integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
+      "requires": {
+        "@emotion/styled-base": "^10.0.27",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
+    "@emotion/styled-base": {
+      "version": "10.0.31",
+      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.31.tgz",
+      "integrity": "sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/is-prop-valid": "0.8.8",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -2356,6 +2465,23 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-emotion": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.29.tgz",
+      "integrity": "sha512-7Jpi1OCxjyz0k163lKtqP+LHMg5z3S6A7vMBfHnF06l2unmtsOmFDzZBpGf0CWo1G4m8UACfVcDJiSiRuu/cSw==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
+      }
+    },
     "babel-plugin-import": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-import/-/babel-plugin-import-1.12.2.tgz",
@@ -2394,6 +2520,11 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.4.tgz",
       "integrity": "sha512-S6d+tEzc5Af1tKIMbsf2QirCcPdQ+mKUCY2H1nJj1DyA1ShwpsoxEOAwbWsG5gcXNV/olpvQd9vrUWRx4bnhpw=="
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -6341,7 +6472,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "promise": {
@@ -6464,6 +6595,11 @@
         "make-dir": "^2.0.0",
         "pkg-dir": "^3.0.0"
       }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "find-up": {
       "version": "2.1.0",
@@ -10200,7 +10336,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@emotion/core": "^10.0.28",
+    "@emotion/styled": "^10.0.27",
     "@sentry/browser": "^5.2.1",
     "@sentry/cli": "^1.49.0",
     "antd": "^3.25.2",

--- a/src/containers/CallIn/ThankYou/CallStats.js
+++ b/src/containers/CallIn/ThankYou/CallStats.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from '@emotion/styled'
 import { Card, Col, Icon, Row, Statistic, Typography } from 'antd';
 
 import { isSenatorDistrict } from '../../../util/district';

--- a/src/containers/CallIn/ThankYou/CallStats.js
+++ b/src/containers/CallIn/ThankYou/CallStats.js
@@ -4,9 +4,6 @@ import { Card, Col, Icon, Row, Statistic, Typography } from 'antd';
 
 import { isSenatorDistrict } from '../../../util/district';
 
-const StatsContainer = styled.div`
-
-`
 const StatCell = ({ title, icon, value, isSen }) => (
     <Col xs={24} sm={isSen ? 24 : 12}>
         <Card style={{height:"100%"}}>
@@ -45,7 +42,7 @@ const CallStats = ({ district, localStats, overallStats }) => {
     )
 
     return (
-        <StatsContainer>
+        <div>
             <Row>
                 <Typography.Title level={3}>Our Impact So Far:</Typography.Title>
             </Row>
@@ -56,7 +53,7 @@ const CallStats = ({ district, localStats, overallStats }) => {
             <Row type="flex" justify="center" align="middle">
                 {repCallers}
             </Row>
-        </StatsContainer>
+        </div>
     )  
 }
 

--- a/src/containers/CallIn/ThankYou/CallStats.js
+++ b/src/containers/CallIn/ThankYou/CallStats.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import styled from '@emotion/styled'
+import { Card, Col, Icon, Row, Skeleton, Statistic, Typography } from 'antd';
+
+import { isSenatorDistrict } from '../../../util/district';
+
+const StatsContainer = styled.div`
+
+`
+const StatCell = ({ title, icon, value, isSen }) => (
+    <Col xs={24} sm={isSen ? 24 : 12}>
+        <Card style={{height:"100%"}}>
+            <Statistic 
+                title={<Typography.Text style={{fontSize: "1.2em"}}>{title}</Typography.Text>} 
+                value={value} 
+                suffix={<Icon type={icon} />} 
+            />
+        </Card>
+    </Col>
+)
+
+const CallStats = ({ district, localStats, overallStats }) => {
+    if (!localStats || !district || !overallStats) {
+        return <Skeleton />
+    }
+    if (district && !district.repLastName) {
+        return null;
+    }
+
+    const localCalls = localStats && localStats.totalCalls;
+    const localCallers = localStats && localStats.totalCallers;
+    const overallCalls = overallStats && overallStats.totalCalls;
+    const overallCallers = overallStats && overallStats.totalCallers;
+
+    if (!localCalls) {
+        return null
+    }
+
+    const isSen = isSenatorDistrict(district);
+    const repName = isSen ? `Senator ${district.repLastName}` : `Rep. ${district.repLastName}`;
+
+    const localCallsCol = <StatCell title={`Total Calls to ${repName}`} value={localCalls} icon="phone" />
+    const overallCallsCol = <StatCell title="Total Calls Nationwide" value={overallCalls} icon="phone" />
+    const localCallersCol = <StatCell title={`People signed up to call ${repName}`} value={localCallers} icon="smile" />
+    const overallCallersCol = <StatCell title="Registered Callers Nationwide" value={overallCallers} icon="smile" isSen={isSen} />
+
+    const repCallers = (
+        <>
+            {!isSen && localCallersCol}
+            {overallCallersCol}
+        </>
+    )
+
+    return (
+        <StatsContainer>
+            <Row>
+                <Typography.Title level={3}>Our Impact So Far:</Typography.Title>
+            </Row>
+            <Row type="flex" justify="center" align="middle">
+                {localCallsCol}
+                {overallCallsCol}
+            </Row>
+            <Row type="flex" justify="center" align="middle">
+                {repCallers}
+            </Row>
+        </StatsContainer>
+    )  
+}
+
+export default CallStats

--- a/src/containers/CallIn/ThankYou/CallStats.js
+++ b/src/containers/CallIn/ThankYou/CallStats.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled'
-import { Card, Col, Icon, Row, Skeleton, Statistic, Typography } from 'antd';
+import { Card, Col, Icon, Row, Statistic, Typography } from 'antd';
 
 import { isSenatorDistrict } from '../../../util/district';
 
@@ -20,10 +20,7 @@ const StatCell = ({ title, icon, value, isSen }) => (
 )
 
 const CallStats = ({ district, localStats, overallStats }) => {
-    if (!localStats || !district || !overallStats) {
-        return <Skeleton />
-    }
-    if (district && !district.repLastName) {
+    if (!district.repLastName) {
         return null;
     }
 
@@ -31,10 +28,6 @@ const CallStats = ({ district, localStats, overallStats }) => {
     const localCallers = localStats && localStats.totalCallers;
     const overallCalls = overallStats && overallStats.totalCalls;
     const overallCallers = overallStats && overallStats.totalCallers;
-
-    if (!localCalls) {
-        return null
-    }
 
     const isSen = isSenatorDistrict(district);
     const repName = isSen ? `Senator ${district.repLastName}` : `Rep. ${district.repLastName}`;

--- a/src/containers/CallIn/ThankYou/OtherCallTargets.js
+++ b/src/containers/CallIn/ThankYou/OtherCallTargets.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Avatar, Button, Typography, Row, Col } from 'antd';
+import styled from '@emotion/styled'
+
+import { isSenatorDistrict } from '../../../util/district';
+
+const OtherCallContainer = styled.div`
+
+`
+const CallLink = styled(Button)`
+    width: 100%;
+    display: flex;
+    align-items: center;
+    height: auto;
+    font-weight: 500;
+    font-size: 1.1rem;
+    margin-bottom: 0.75rem;
+`
+const StyledAvatar = styled(Avatar)`
+    margin-top: 0.5rem;
+    margin-right: 0.5rem;
+    margin-bottom: 0.5rem;
+    border-style: solid;
+    border-width: 2px;
+`
+
+const OtherCallTargets = ({ districts = [] }) => {
+    const callTargets = districts
+        .filter(callTarget => !!callTarget)
+        .map(callTarget => {
+            const link = `/call/${callTarget.state}/${callTarget.number}`
+            return (    
+                <CallLink
+                    key={link}
+                    type="primary"
+                    target="_blank"
+                    href={link}
+                >
+                    <StyledAvatar size={64} shape="square" src={callTarget.repImageUrl} />
+                    {`Call ${isSenatorDistrict(callTarget) ? "Senator" : "Representative"} ${callTarget.repLastName}`}
+                </CallLink>   
+            )
+        })
+
+    return (
+        <div>
+            <Typography.Title level={3}>Here's how you can do a little more:</Typography.Title>
+            {callTargets}
+        </div>
+    )
+}
+
+export default OtherCallTargets

--- a/src/containers/CallIn/ThankYou/OtherCallTargets.js
+++ b/src/containers/CallIn/ThankYou/OtherCallTargets.js
@@ -1,12 +1,9 @@
 import React from 'react';
-import { Avatar, Button, Typography, Row, Col } from 'antd';
+import { Avatar, Button, Typography } from 'antd';
 import styled from '@emotion/styled'
 
 import { isSenatorDistrict } from '../../../util/district';
 
-const OtherCallContainer = styled.div`
-
-`
 const CallLink = styled(Button)`
     width: 100%;
     display: flex;

--- a/src/containers/CallIn/ThankYou/OtherCallTargets.js
+++ b/src/containers/CallIn/ThankYou/OtherCallTargets.js
@@ -25,22 +25,20 @@ const StyledAvatar = styled(Avatar)`
 `
 
 const OtherCallTargets = ({ districts = [] }) => {
-    const callTargets = districts
-        .filter(callTarget => !!callTarget)
-        .map(callTarget => {
-            const link = `/call/${callTarget.state}/${callTarget.number}`
-            return (    
-                <CallLink
-                    key={link}
-                    type="primary"
-                    target="_blank"
-                    href={link}
-                >
-                    <StyledAvatar size={64} shape="square" src={callTarget.repImageUrl} />
-                    {`Call ${isSenatorDistrict(callTarget) ? "Senator" : "Representative"} ${callTarget.repLastName}`}
-                </CallLink>   
-            )
-        })
+    const callTargets = districts.map(callTarget => {
+        const link = `/call/${callTarget.state}/${callTarget.number}`
+        return (    
+            <CallLink
+                key={link}
+                type="primary"
+                target="_blank"
+                href={link}
+            >
+                <StyledAvatar size={64} shape="square" src={callTarget.repImageUrl} />
+                {`Call ${isSenatorDistrict(callTarget) ? "Senator" : "Representative"} ${callTarget.repLastName}`}
+            </CallLink>   
+        )
+    })
 
     return (
         <div>

--- a/src/containers/CallIn/ThankYou/ThankYou.js
+++ b/src/containers/CallIn/ThankYou/ThankYou.js
@@ -1,17 +1,38 @@
 import React, { Component } from 'react';
 import { Card, Col, Divider, Icon, message, Row, Skeleton, Statistic, Typography } from 'antd';
 import { Redirect } from 'react-router-dom';
+import styled from '@emotion/styled'
 
 import SimpleLayout from '../../Layout/SimpleLayout/SimpleLayout';
 import axios from '../../../util/axios-api';
 import getUrlParameter from '../../../util/urlparams';
-import {isSenatorDistrict} from '../../../util/district';
-
-import styles from './ThankYou.module.css';
 
 import capitol from '../../../assets/images/capitol-group.jpg';
 import discussion from '../../../assets/images/discussion.jpeg';
 import grassroots from '../../../assets/images/grassroots.jpg';
+import OtherCallTargets from './OtherCallTargets';
+import CallStats from './CallStats';
+
+
+const CONTENT_WIDTH_PX = 900
+const StyledRow = styled(Row)`
+    background: ${props => props.bg};
+    padding: 1.4em;
+
+    @media (min-width: ${CONTENT_WIDTH_PX + 20}px) {
+        padding: 2em calc(50vw - ${CONTENT_WIDTH_PX / 2}px);
+    }
+`
+const ColorContentRow = ({ bg, children}) => (
+    <StyledRow 
+        bg={bg || 'transparent'} 
+        type="flex" 
+        justify="center" 
+        gutter={[20, 20]}
+    >
+        {children}
+    </StyledRow>
+)
 
 class ThankYou extends Component {
 
@@ -134,143 +155,73 @@ class ThankYou extends Component {
         
     }
 
-    getStatsJSX = () => {
-        if (this.state.statsError) {
-            return null;
-        }
-        if (!this.state.localStats || !this.state.district || !this.state.overallStats) {
-            return <Skeleton />;
-        }
-        if (this.state.district && !this.state.district.repLastName) {
-            return null;
-        }
-
-        const localCalls = this.state.localStats && this.state.localStats.totalCalls;
-        const localCallers = this.state.localStats && this.state.localStats.totalCallers;
-        const overallCalls = this.state.overallStats && this.state.overallStats.totalCalls;
-        const overallCallers = this.state.overallStats && this.state.overallStats.totalCallers;
-        const isSen = isSenatorDistrict(this.state.district);
-        const repName = isSen ? `Senator ${this.state.district.repLastName}` : `Rep. ${this.state.district.repLastName}`;
-
-        const overallCallsCol = (<Col xs={24} sm={12} md={6} className={styles.StatCol}>
-            <Card style={{height:"100%"}}><Statistic title={<Typography.Text style={{fontSize: "1.2em"}}>Total Calls Nationwide</Typography.Text>} value={overallCalls} suffix={<Icon type="phone" />} /></Card>
-        </Col>);
-        const localCallsCol = (<Col xs={24} sm={12} md={6} className={styles.StatCol}>
-            <Card style={{height:"100%"}}><Statistic title={<Typography.Text style={{fontSize: "1.2em"}}>{`Total Calls to ${repName}`}</Typography.Text>} value={localCalls} suffix={<Icon type="phone" />} /></Card>
-        </Col>);
-        const localCallersCol = (<Col xs={24} sm={12} md={6} className={styles.StatCol}>
-            <Card style={{height:"100%"}}><Statistic title={<Typography.Text style={{fontSize: "1.2em"}}>{`People signed up to call ${repName}`}</Typography.Text>} value={localCallers} suffix={<Icon type="smile" />} /></Card>
-        </Col>);
-        const overallCallersCol = (<Col xs={24} sm={isSen ? 24 : 12} md={isSen ? 12 : 6} className={styles.StatCol}>
-            <Card style={{height:"100%"}}><Statistic title={<Typography.Text style={{fontSize: "1.2em"}}>Registered Callers Nationwide</Typography.Text>} value={overallCallers} suffix={<Icon type="smile" />} /></Card>
-        </Col>);
-
-        const senCallers = overallCallersCol;
-        const repCallers = (
-            <>
-            {localCallersCol}
-            {overallCallersCol}
-            </>
-        )
-
-        return (
-            <>
-                <div style={{ background: '#ECECEC', padding: '20px', display: localCalls > 0 ? 'block' : 'none' }}>
-                    <Row className={styles.Heading}>
-                        <Typography.Title level={3}>Our Impact So Far:</Typography.Title>
-                    </Row>
-                    <Row type="flex" justify="center" align="middle">
-                        {localCallsCol}
-                        {overallCallsCol}
-                    </Row>
-                    <Row type="flex" justify="center" align="middle">
-                    { isSen ? senCallers : repCallers}
-                    </Row>
-                </div>
-                <Divider />
-            </>
-        );        
-    }
-
-    getOtherCallTargetCards = () => {
-        return this.state.eligibleCallTargets && this.state.eligibleCallTargets.filter(el=>{return el !== undefined && el !== null}).map(el => {
-            return (
-                <Col xs={24} sm={12} md={12} lg={12} xl={8} key={el.districtId}>
-                    <Card
-                        cover={<img alt="representative portrait" src={el.repImageUrl} />}
-                        actions={[<Icon type="phone" onClick={()=>{this.openInNewTab(`https://cclcalls.org/call/${el.state}/${el.number}`)}}/>]}
-                    >
-                        <Card.Meta
-                        title={`Call ${isSenatorDistrict(el) ? "Senator" : "Representative"} ${el.repLastName}`}
-                        description={`Itching to call more people? Give ${isSenatorDistrict(el) ? "Senator" : "Representative"} ${el.repLastName} a ring.`}
-                        />
-                    </Card>
-                </Col>
-            )
-        })
-    }
-
     render() {
-        
         if (this.state.signUpRedirect) {
             return <Redirect to="/signup" />
         }
 
-        const pitch = this.state.localStats ? "Please help us make a bigger impact:" : "Here's how you can do a little more:";
-
         return (
             <SimpleLayout activeLinkKey="/signup">
-                <Row type="flex" justify="center">
-                    <Col xs={24} md={20} lg={18} xl={16}>
-                        <div className={styles.ThankYou}>
-                    <div className={styles.Heading}>
+                <ColorContentRow bg="#ececec">
+                    <Col xs={24} align="center">
                         <Typography.Title level={1}>Thank You for Calling</Typography.Title>
-                    </div>
-                    { this.getStatsJSX() }
-                    <div className={styles.Heading}>
-                        <Typography.Title level={3}>{pitch}</Typography.Title>
-                    </div>
-                    <Row type="flex" gutter={[4, 4]}>
-                        {this.getOtherCallTargetCards()}
-                        {
-                            !this.state.identifier && (<Col xs={24} sm={12} md={12} lg={12} xl={8}>
-                                <Card
-                                    cover={<img alt="US Captitol Building" src={capitol} />}
-                                    actions={[<Icon type="user-add" onClick={()=>{this.setState({signUpRedirect: true})}} />]}
-                                >
-                                    <Card.Meta
-                                    title="Sign Up for Call Reminders"
-                                    description="If you haven't done it already, sign up to get a monthly call reminder."
-                                    />
-                                </Card>
-                            </Col>)
-                        }
-                        <Col xs={24} sm={12} md={12} lg={12} xl={8}>
-                            <Card
-                                cover={<img alt="US Captitol Building" src={discussion} />}
-                                actions={[<Icon type="facebook" onClick={()=>{this.handleShare('facebook')}} />, <Icon type="twitter" onClick={()=>{this.handleShare('twitter')}} />, <Icon type="mail" onClick={()=>{this.handleShare('email')}} />]}
-                            >
-                                <Card.Meta
-                                title="Share the Calling Congress Campaign"
-                                description="The more people who call, the more our representatives listen. Spread the word."
-                                />
-                            </Card>
-                        </Col>
-                        <Col xs={24} sm={12} md={12} lg={12} xl={8}>
-                            <Card
-                                cover={<img alt="Volunteer with clipboard" src={grassroots} />}
-                                actions={[<Icon type="user-add" onClick={()=>{this.openInNewTab('https://citizensclimatelobby.org/join-citizens-climate-lobby/')}}/>]}
-                            >
-                                <Card.Meta
-                                title="Join Citizens' Climate Lobby"
-                                description="CCL volunteers created this site, and we would love for you to join us."
-                                />
-                            </Card>
-                        </Col>
-                    </Row>
-                </div>
                     </Col>
-                </Row>
+                    <Col sm={24} md={12} lg={14}>
+                        { this.state.statsError || (
+                            <CallStats 
+                                district={this.state.district} 
+                                localStats={this.state.localStats} 
+                                overallStats={this.state.overallStats} 
+                            /> 
+                        )}
+                    </Col>
+                    <Col sm={24} md={12} lg={10}>
+                        {this.state.eligibleCallTargets && (
+                            <OtherCallTargets districts={this.state.eligibleCallTargets} />
+                        )}
+                    </Col>
+                </ColorContentRow>
+                <ColorContentRow>
+                    {
+                        !this.state.identifier && (<Col xs={24} sm={12} lg={8}>
+                            <Card
+                                cover={<img alt="US Captitol Building" src={capitol} />}
+                                actions={[<Icon type="user-add" onClick={()=>{this.setState({signUpRedirect: true})}} />]}
+                            >
+                                <Card.Meta
+                                title="Sign Up for Call Reminders"
+                                description="If you haven't done it already, sign up to get a monthly call reminder."
+                                />
+                            </Card>
+                        </Col>)
+                    }
+                    <Col xs={24} sm={12} lg={8}>
+                        <Card
+                            cover={<img alt="US Captitol Building" src={discussion} />}
+                            actions={[
+                                <Icon type="facebook" onClick={()=>{this.handleShare('facebook')}} />, 
+                                <Icon type="twitter" onClick={()=>{this.handleShare('twitter')}} />, 
+                                <Icon type="mail" onClick={()=>{this.handleShare('email')}} />
+                            ]}
+                        >
+                            <Card.Meta
+                            title="Share the Calling Congress Campaign"
+                            description="The more people who call, the more our representatives listen. Spread the word."
+                            />
+                        </Card>
+                    </Col>
+                    <Col xs={24} sm={12} lg={8}>
+                        <Card
+                            cover={<img alt="Volunteer with clipboard" src={grassroots} />}
+                            actions={[<Icon type="user-add" onClick={()=>{this.openInNewTab('https://citizensclimatelobby.org/join-citizens-climate-lobby/')}}/>]}
+                        >
+                            <Card.Meta
+                            title="Join Citizens' Climate Lobby"
+                            description="CCL volunteers created this site, and we would love for you to join us."
+                            />
+                        </Card>
+                    </Col>
+                </ColorContentRow>
             </SimpleLayout>
         )
     }

--- a/src/containers/CallIn/ThankYou/ThankYou.js
+++ b/src/containers/CallIn/ThankYou/ThankYou.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Card, Col, Divider, Icon, message, Row, Skeleton, Statistic, Typography } from 'antd';
+import { Card, Col, Icon, message, Row, Typography } from 'antd';
 import { Redirect } from 'react-router-dom';
 import styled from '@emotion/styled'
 


### PR DESCRIPTION
For #27 

## Description
![image](https://user-images.githubusercontent.com/2737888/77241402-d6c5f300-6bae-11ea-9656-2efd0f0d94d0.png)

I decided to do a quick redesign of the Thank You Page while I added the ability to filter out `covid_paused` offices. This redesign mostly brings the other call actions as buttons up above the fold, but still after the stats. 

## Test Plan
`// TODO`
I haven't tested this with an API that actually returns `status` for offices yet. I will update this PR once I do. 