### PR TITLE
thank you for signing up page handles covid status

### DIFF
--- a/src/containers/SignUp/SignUp.js
+++ b/src/containers/SignUp/SignUp.js
@@ -18,7 +18,7 @@ class SignUp extends Component {
     }
 
     handleFormSubmit = (fieldsValues) => {
-        const {district, zipCode, firstName, lastName, phone, email, } = {...fieldsValues};
+        const { district, zipCode, firstName, lastName, phone, email } = fieldsValues
         const caller = {
             districtId: district.districtId,
             zipCode: zipCode,

--- a/src/containers/SignUp/SignUp.js
+++ b/src/containers/SignUp/SignUp.js
@@ -21,9 +21,9 @@ class SignUp extends Component {
         const { district, zipCode, firstName, lastName, phone, email } = fieldsValues
         const caller = {
             districtId: district.districtId,
-            zipCode: zipCode,
-            firstName: firstName,
-            lastName: lastName,
+            zipCode,
+            firstName,
+            lastName,
         }
         
         const communicationMethods = [];

--- a/src/containers/SignUp/SignUp.js
+++ b/src/containers/SignUp/SignUp.js
@@ -12,36 +12,32 @@ class SignUp extends Component {
 
     state = {
         didSignUp: false,
-        state: null,
         district: null,
         communicationMethods: null,
         postCallerDetailsError: null
     }
 
     handleFormSubmit = (fieldsValues) => {
-        const {congressionalDistrict} = {...fieldsValues};
-        const state = congressionalDistrict[0];
-        const district = congressionalDistrict[1];
-        
+        const {district, zipCode, firstName, lastName, phone, email, } = {...fieldsValues};
         const caller = {
-            districtId: fieldsValues.districtId,
-            zipCode: fieldsValues.zipCode,
-            firstName: fieldsValues.firstName,
-            lastName: fieldsValues.lastName,
+            districtId: district.districtId,
+            zipCode: zipCode,
+            firstName: firstName,
+            lastName: lastName,
         }
         
         const communicationMethods = [];
-        if (fieldsValues.phone) {
+        if (phone) {
             communicationMethods.push('sms');
-            caller['phone'] = fieldsValues.phone;
+            caller['phone'] = phone;
         }
-        if (fieldsValues.email) {
+        if (email) {
             communicationMethods.push('email');
-            caller['email'] = fieldsValues.email;
+            caller['email'] = email;
         }
         caller['contactMethods'] = communicationMethods;
         axios.post('callers', caller).then((response)=>{
-            this.process_happy_signup(state, district, communicationMethods)
+            this.process_happy_signup(district, communicationMethods)
         }).catch((error)=>{            
             const errMessage = error.response.data.message;
             const isDupe = errMessage.includes('Duplicate entry');
@@ -67,9 +63,8 @@ class SignUp extends Component {
         });
     }
 
-    process_happy_signup = (state, district, communicationMethods) => {
+    process_happy_signup = (district, communicationMethods) => {
         this.setState({
-            state: state,
             district: district,
             communicationMethods: communicationMethods,
             didSignUp: true
@@ -78,10 +73,11 @@ class SignUp extends Component {
 
     render() { 
         if (this.state.didSignUp) {
+            const {state, number, status} = this.state.district;
             return <Redirect
                 to={{
                 pathname: "/signup/thankyou",
-                search: `?state=${this.state.state}&district=${this.state.district}&com=${this.state.communicationMethods.join('-')}`
+                search: `?state=${state}&district=${number}&com=${this.state.communicationMethods.join('-')}&status=${status}`
             }}
           />;
         }

--- a/src/containers/SignUp/SignUpForm/SignUpForm.js
+++ b/src/containers/SignUp/SignUpForm/SignUpForm.js
@@ -63,10 +63,10 @@ class SignUpForm extends Component {
             
         }
         const fieldValues = this.props.form.getFieldsValue();
-        fieldValues['districtId'] = this.state.congressionalDistricts.find((district)=>{
+        fieldValues['district'] = this.state.congressionalDistricts.find((district)=>{
             return district.state === fieldValues.congressionalDistrict[0] && district.number === fieldValues.congressionalDistrict[1];
-        }).districtId;
-        if (fieldValues.districtId) {
+        });
+        if (fieldValues.district) {
             this.props.onSuccessfulSubmit(fieldValues);
         }
     }

--- a/src/containers/SignUp/ThankYou/ThankYou.js
+++ b/src/containers/SignUp/ThankYou/ThankYou.js
@@ -32,8 +32,7 @@ class ThankYou extends Component {
         title: "What is Citizens' Climate Lobby?",
         description: "Learn more about us",
         handler: () => {
-            const win = window.open('https://citizensclimatelobby.org/about-ccl/', '_blank');
-            win.focus();
+            window.location.href = 'https://citizensclimatelobby.org/about-ccl/';
         }
     }
 

--- a/src/containers/SignUp/ThankYou/ThankYou.js
+++ b/src/containers/SignUp/ThankYou/ThankYou.js
@@ -13,37 +13,51 @@ class ThankYou extends Component {
     state = {
         makeFirstCall: false,
         state: null,
-        district: null,
-        communicationMethod: null
+        districtNumber: null,
+        communicationMethod: null,
+        districtStatus: 'active'
     }
 
-    handleMakeCallClick = (event) => {
-        console.log('hi');
-        this.setState({
-            makeFirstCall: true
-        })
+    followUpActionActiveDistrict = {
+        title: "Can't wait to start calling?",
+        description: "Make your first call now!",
+        handler: () => {
+            this.setState({
+                makeFirstCall: true
+            })
+        }
+    }
+
+    followUpActionCovidPausedDistrict = {
+        title: "What is Citizens' Climate Lobby?",
+        description: "Learn more about us",
+        handler: () => {
+            const win = window.open('https://citizensclimatelobby.org/about-ccl/', '_blank');
+            win.focus();
+        }
     }
 
     componentDidMount = () => {
-
         const params = this.props.location.search;
         const communicationMethods = getUrlParameter(params, 'com').split('-');
         const communicationMethod = communicationMethods.length > 1 ? communicationMethods.join(' and ') : communicationMethods[0]
         this.setState({
             communicationMethod: communicationMethod,
             state: getUrlParameter(params, 'state'),
-            district: getUrlParameter(params, 'district')
+            districtNumber: getUrlParameter(params, 'district'),
+            districtStatus: getUrlParameter(params, 'status')
         });
     }
 
+    
     render() {  
-
-
         if (this.state.makeFirstCall) {
             return <Redirect
-                to={{pathname: `/call/${this.state.state}/${this.state.district}`}}
+                to={{pathname: `/call/${this.state.state}/${this.state.districtNumber}`}}
             />;
         }
+
+        const followUpAction = this.state.districtStatus === 'covid_paused' ? this.followUpActionCovidPausedDistrict : this.followUpActionActiveDistrict;
 
         return (
             <ResponsiveLayout activeLinkKey="/signup">
@@ -59,8 +73,8 @@ class ThankYou extends Component {
                                 </Typography.Paragraph>
                                 <img src={capitol} className={styles.Photo} alt="U.S. Capitol Building" />
                                 <div className={styles.CantWait}>
-                                    <Typography.Title level={4}>Can't wait to start calling?</Typography.Title>
-                                    <Button block onClick={this.handleMakeCallClick} type="primary">Make your first call now!</Button>
+                                    <Typography.Title level={4}>{followUpAction.title}</Typography.Title>
+                                    <Button block onClick={() => followUpAction.handler()} type="primary">{followUpAction.description}</Button>
                                 </div>
                             </div>
                         </Col>


### PR DESCRIPTION
closes #25 

![Screen Shot 2020-03-22 at 12 53 21 PM](https://user-images.githubusercontent.com/1223720/77256436-3fa77c80-6c3c-11ea-9a37-a114ed8978db.png)

* Thank you for signing up normally invites new callers to make their first call
* If the district is disabled due to coronavirus, we instead fall back to "what is ccl?"
* took the opportunity to clear up naming confusion by setting `district` to an actual district object, similar to everywhere else in the code.