### PR TITLE
Add a short command to start the public UI for development, and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 ## Developing with pgc-api
 
-To connect to a local instance of pgc-api, run `npm start` with the environment variable `REACT_APP_API_ENDPOINT=<url>`. By default, pgc-api listens on `http://localhost:8080/api`, so that would look like:
+Run `./run.sh start`
 
-`REACT_APP_API_ENDPOINT=http://localhost:8080//api/ npm start`
+This will connect to the default pgc-api port on localhost (`http://localhost:8080/api`) and start the frontend service.
 
 ## Available Scripts
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 ## Developing with pgc-api
 
-Run `./run.sh start`
+Run `npm run local`
 
 This will connect to the default pgc-api port on localhost (`http://localhost:8080/api`) and start the frontend service.
 

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
     "typeface-ubuntu": "^0.0.65"
   },
   "scripts": {
-    "start": "react-app-rewired start",
-    "build": "react-app-rewired build",
-    "test": "react-app-rewired test",
+    "start": "./run.sh start",
+    "local": "./run.sh local",
+    "build": "./run.sh build",
+    "test": "./run.sh test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,23 @@
 #!/bin/bash
 
+export PATH=$PATH:node_modules/.bin
+
 start() {
+  react-app-rewired start
+}
+
+local() {
   export REACT_APP_API_ENDPOINT=http://localhost:8080/api/
-  npm start
+  echo "Starting server, talking to API at $REACT_APP_API_ENDPOINT"
+  react-app-rewired start
+}
+
+build() {
+  react-app-rewired build
+}
+
+test() {
+  react-app-rewired test
 }
 
 "$@"

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 
 start() {
   export REACT_APP_API_ENDPOINT=http://localhost:8080/api/
-  yarn start
+  npm start
 }
 
 "$@"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+start() {
+  export REACT_APP_API_ENDPOINT=http://localhost:8080/api/
+  yarn start
+}
+
+"$@"


### PR DESCRIPTION
Without this, I'm surely going to forget to set the environment variable to connect to my local pgc-api instead of the remote one.  Again :)