### PR TITLE
Reduced src/redux/actions.test.js precision by 1 decimal place

### DIFF
--- a/src/redux/actions.test.js
+++ b/src/redux/actions.test.js
@@ -8,6 +8,6 @@ describe("actions", () => {
     expect(actualAction.type).toBe(types.LOG_CALL);
     expect(actualAction.payload).toBeDefined();
     expect(actualAction.payload.districtId).toBe(districtId);
-    expect(actualAction.payload.timestamp).toBeCloseTo(Date.now(), -2);
+    expect(actualAction.payload.timestamp).toBeCloseTo(Date.now(), -1);
   });
 });


### PR DESCRIPTION
This is the test case you mentioned it fails sometimes because the precision is too high. This is a 1 char pr. 