### PR TITLE
Handle no tracking

### DIFF
--- a/src/containers/CallIn/CallIn.test.js
+++ b/src/containers/CallIn/CallIn.test.js
@@ -19,7 +19,7 @@ describe("CallIn", () => {
 
     const { queryByText, findByText } = render(
       <MemoryRouter>
-        <CallIn history={history} />
+        <CallIn history={history} logNotification={() => {}} />
         <Route path={path} render={(props) => { 
           return <h1>{props.location.search}</h1>
         }} />
@@ -42,7 +42,7 @@ describe("CallIn", () => {
 
     const { queryByText, findByText } = render(
       <MemoryRouter>
-        <CallIn history={history} />
+        <CallIn history={history} logNotification={() => {}} />
         <Route path={path} render={(props) => { 
           return <h1>{props.location.search}</h1>
         }} />
@@ -55,6 +55,34 @@ describe("CallIn", () => {
     fireEvent.click(skipButton);
     await waitFor(() => findByText(search));
     expect(queryByText(search)).toBeDefined();
+  });
+
+  test("logNotification() invoked on page load", async () => {
+    const history = createMemoryHistory();
+    history.push("/call/wa/-1?t=123456&d=9&c=1234");
+
+    const expectedCaller = "1234"
+    const expectedTrackingId = "123456"
+    const expectedDistrict = "9"
+
+    let actualCaller = null;
+    let actualTrackingId = null;
+    let actualDistrict = null;
+
+    render(
+      <MemoryRouter>
+        <CallIn history={history} logNotification={(caller, identifier, homeDistrict) => { 
+          actualCaller = caller
+          actualTrackingId = identifier
+          actualDistrict = homeDistrict
+         }} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => actualCaller != null);
+    expect(actualCaller).toBe(expectedCaller)
+    expect(actualDistrict).toBe(expectedDistrict)
+    expect(actualTrackingId).toBe(expectedTrackingId)
   });
 
 });

--- a/src/containers/CallIn/ThankYou/ThankYou.js
+++ b/src/containers/CallIn/ThankYou/ThankYou.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Button, Card, Col, Icon, message, Row, Typography } from 'antd';
+import { Button, Card, Col, Icon, message, Modal, Row, Typography } from 'antd';
 import { Redirect } from 'react-router-dom';
 import styled from '@emotion/styled'
 import { connect } from "react-redux";
@@ -167,6 +167,24 @@ export class ThankYou extends Component {
                 callWasReported: true,
                 callWasTracked: false
             });
+
+            Modal.error({
+                title: <Typography.Title level={2}>Your call was not tracked by CCL</Typography.Title>,
+                content: (
+                    <>
+                        <Typography.Title level={3}>If you want credit for this call:</Typography.Title>
+                        <Typography.Title level={4}>📱 Text Message Subscribers:</Typography.Title>
+                        <Typography.Text>
+                            Open the link in the most recent text message and click the "Report your call" button from that page.
+                        </Typography.Text>
+                        <Typography.Title level={4}>✉️ Email Subscribers:</Typography.Title>
+                        <Typography.Text>
+                            Find the most recent email from MCC and click the "Report your call" button from that email.
+                        </Typography.Text>
+                    </>
+                  )
+              });
+
         });
     }
 

--- a/src/containers/CallIn/ThankYou/ThankYou.js
+++ b/src/containers/CallIn/ThankYou/ThankYou.js
@@ -173,11 +173,11 @@ export class ThankYou extends Component {
                 content: (
                     <>
                         <Typography.Title level={3}>If you want credit for this call:</Typography.Title>
-                        <Typography.Title level={4}>📱 Text Message Subscribers:</Typography.Title>
+                        <Typography.Title level={4}><span role="img" aria-label="smartphone">📱</span> Text Message Subscribers:</Typography.Title>
                         <Typography.Text>
                             Open the link in the most recent text message and click the "Report your call" button from that page.
                         </Typography.Text>
-                        <Typography.Title level={4}>✉️ Email Subscribers:</Typography.Title>
+                        <Typography.Title level={4}><span role="img" aria-label="envelope">✉️</span> Email Subscribers:</Typography.Title>
                         <Typography.Text>
                             Find the most recent email from MCC and click the "Report your call" button from that email.
                         </Typography.Text>

--- a/src/redux/actionTypes.js
+++ b/src/redux/actionTypes.js
@@ -1,1 +1,2 @@
 export const LOG_CALL = "LOG_CALL";
+export const LOG_NOTIFICATION = "LOG_NOTIFICATION";

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -1,9 +1,19 @@
-import { LOG_CALL } from "./actionTypes";
+import { LOG_CALL, LOG_NOTIFICATION } from "./actionTypes";
 
 export const logCall = districtId => ({
   type: LOG_CALL,
   payload: {
     districtId,
+    timestamp: Date.now()
+  }
+});
+
+export const logNotification = (callerId, trackingId, homeDistrict) => ({
+  type: LOG_NOTIFICATION,
+  payload: {
+    callerId,
+    trackingId,
+    homeDistrict,
     timestamp: Date.now()
   }
 });

--- a/src/redux/reducers/calls.js
+++ b/src/redux/reducers/calls.js
@@ -1,7 +1,7 @@
 import { LOG_CALL } from "../actionTypes";
 
 const initialState = {
-  byId: {},
+    byId: {}
 };
 
 export default function (state = initialState, action) {

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -1,4 +1,5 @@
 import { combineReducers } from "redux";
 import calls from "./calls";
+import notification from "./notification";
 
-export default combineReducers({ calls });
+export default combineReducers({ calls, notification });

--- a/src/redux/reducers/notification.js
+++ b/src/redux/reducers/notification.js
@@ -1,0 +1,27 @@
+import { LOG_NOTIFICATION } from "../actionTypes";
+
+const initialState = {
+  notification: {},
+};
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case LOG_NOTIFICATION: {
+      const { callerId, trackingId, homeDistrict, timestamp } = action.payload;
+      if (!callerId || !trackingId || !homeDistrict) {
+        return state;
+      }
+      const latest = {
+        callerId,
+        homeDistrict,
+        timestamp,
+        trackingId,
+      };
+      const newState = { ...state };
+      newState.notification = latest;
+      return latest;
+    }
+    default:
+      return state;
+  }
+}

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,16 +1,16 @@
 import { createStore } from 'redux';
 import rootReducer from './reducers';
-import { loadCalls, saveCalls } from '../util/localStorage'
+import { loadCallsAndNotifications, saveCalls, saveNotification } from '../util/localStorage'
 
-const localStorageCalls = loadCalls();
+const load = loadCallsAndNotifications();
 
 export const store = createStore(
     rootReducer,
-    localStorageCalls
+    load
 );
 
 store.subscribe(() => {
-    saveCalls({
-      calls: store.getState().calls
-    });
+    console.log(store.getState())
+    saveCalls(store.getState().calls);
+    saveNotification(store.getState().notification)
   });

--- a/src/util/localStorage.js
+++ b/src/util/localStorage.js
@@ -1,20 +1,34 @@
-export const loadCalls = () => {
-    try {
-      const serializedState = localStorage.getItem('calls');
-      if (serializedState === null) {
-        return undefined;
-      }
-      return JSON.parse(serializedState);
-    } catch (err) {
+export const loadCallsAndNotifications = () => {
+  const calls = _load("calls")
+  const notification = _load("notification")
+  return { calls, notification }
+};
+
+export const saveNotification = (notification) => {
+  _save("notification", notification)
+};
+
+export const saveCalls = (calls) => {
+  _save("calls", calls)
+};
+
+const _load = (itemType) => {
+  try {
+    const serializedState = localStorage.getItem(itemType);
+    if (serializedState === null) {
       return undefined;
     }
-  };
+    return JSON.parse(serializedState);
+  } catch (err) {
+    return undefined;
+  }
+}
 
-  export const saveCalls = (calls) => {
-    try {
-      const serializedState = JSON.stringify(calls);
-      localStorage.setItem('calls', serializedState);
-    } catch {
-      // ignore write errors
-    }
-  };
+const _save = (itemType, items) => {
+  try {
+    const serializedState = JSON.stringify(items);
+    localStorage.setItem(itemType, serializedState);
+  } catch {
+    // ignore write errors
+  }
+}


### PR DESCRIPTION



1. On the Thank you page, I've added a pop-up that informs callers when their call was not successfully reported, and it offers steps to getting credit.

<img width="431" alt="image" src="https://user-images.githubusercontent.com/1223720/127781264-8f05cba1-acb0-4d52-ab14-4dfed25dcaf8.png">



2. There is a particular bug which took a long time to discover (with help from an extremely detailed report by a CCLer in NV). Without going into the boring details, the call can go unreported if the call-in guide is loaded into a web browser and the page gets refreshed. The fix enables reporting after page refreshes. This mostly affects people who get their notification by text message